### PR TITLE
Remove maintainers mistakenly added

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,5 +34,3 @@ extra:
   recipe-maintainers:
     - ericdill
     - janschulz
-    - licode
-    - tacaswell


### PR DESCRIPTION
I was mistaken about having this as part of our stack.  I'll happily remain as a maintainer, but am removing my coworkers as per their request.  My mistake @janschulz 
